### PR TITLE
Update CreateInvoiceResponse to match lnbits 1.0 API 

### DIFF
--- a/src/api/invoice.rs
+++ b/src/api/invoice.rs
@@ -12,8 +12,8 @@ use super::{LNBitsEndpoint, LNBitsRequestKey};
 pub struct CreateInvoiceResponse {
     /// Payment hash
     pub payment_hash: String,
-    /// Payment request (bolt11)
-    pub payment_request: String,
+    /// Bolt11
+    pub bolt11: String,
 }
 
 /// Pay invoice response


### PR DESCRIPTION
Lnbits 1.0 has changed field name for `CreateInvoiceResponse` from `payment_request` to `bolt11`